### PR TITLE
adds explicit killing of workers

### DIFF
--- a/torch_ac/utils/penv.py
+++ b/torch_ac/utils/penv.py
@@ -12,6 +12,8 @@ def worker(conn, env):
         elif cmd == "reset":
             obs = env.reset()
             conn.send(obs)
+        elif cmd == "kill":
+            return
         else:
             raise NotImplementedError
 
@@ -33,6 +35,10 @@ class ParallelEnv(gym.Env):
             p.daemon = True
             p.start()
             remote.close()
+
+    def __del__(self):
+        for local in self.locals:
+            local.send(("kill", None))
 
     def reset(self):
         for local in self.locals:


### PR DESCRIPTION
We ran into some problems when using the ParallelEnv class for some environments, where it seems that workers were not being killed properly.  This update simply adds explicit destruction of workers.