### PR TITLE
Allow frozen parameters with requires_grad=False

### DIFF
--- a/torch_ac/algos/ppo.py
+++ b/torch_ac/algos/ppo.py
@@ -103,8 +103,8 @@ class PPOAlgo(BaseAlgo):
 
                 self.optimizer.zero_grad()
                 batch_loss.backward()
-                grad_norm = sum(p.grad.data.norm(2).item() ** 2 for p in self.acmodel.parameters()) ** 0.5
-                torch.nn.utils.clip_grad_norm_(self.acmodel.parameters(), self.max_grad_norm)
+                grad_norm = sum(p.grad.data.norm(2).item() ** 2 for p in self.acmodel.parameters() if p.requires_grad) ** 0.5
+                torch.nn.utils.clip_grad_norm_([p for p in self.acmodel.parameters() if p.requires_grad], self.max_grad_norm)
                 self.optimizer.step()
 
                 # Update log values


### PR DESCRIPTION
Hi Lucas, thanks for open-sourcing your code for this project. I think it would be nice to be able to manually freeze some network parameters (I was doing this in the context of transfer learning). Currently, the gradient norm is computed over parameters with `requires_grad=False` as well and `p.grad` is `None`. 