### PR TITLE
adapt to changes in gym

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "numpy>=1.13.0",
-        "torch>=1.0.0"
-    ]
+        "torch>=1.0.0",
+        "multiprocess >= 0.70",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     install_requires=[
         "numpy>=1.13.0",
         "torch>=1.0.0",
-        "multiprocess >= 0.70",
+        "multiprocess>=0.70",
     ],
 )

--- a/torch_ac/algos/base.py
+++ b/torch_ac/algos/base.py
@@ -4,11 +4,26 @@ import torch
 from torch_ac.format import default_preprocess_obss
 from torch_ac.utils import DictList, ParallelEnv
 
+
 class BaseAlgo(ABC):
     """The base class for RL algorithms."""
 
-    def __init__(self, envs, acmodel, device, num_frames_per_proc, discount, lr, gae_lambda, entropy_coef,
-                 value_loss_coef, max_grad_norm, recurrence, preprocess_obss, reshape_reward):
+    def __init__(
+        self,
+        envs,
+        acmodel,
+        device,
+        num_frames_per_proc,
+        discount,
+        lr,
+        gae_lambda,
+        entropy_coef,
+        value_loss_coef,
+        max_grad_norm,
+        recurrence,
+        preprocess_obss,
+        reshape_reward,
+    ):
         """
         Initializes a `BaseAlgo` instance.
 
@@ -40,7 +55,7 @@ class BaseAlgo(ABC):
             and converts them into the format that the model can handle
         reshape_reward : function
             a function that shapes the reward, takes an
-            (observation, action, reward, done) tuple as an input
+            (observation, action, reward, terminated) tuple as an input
         """
 
         # Store parameters
@@ -79,10 +94,14 @@ class BaseAlgo(ABC):
         shape = (self.num_frames_per_proc, self.num_procs)
 
         self.obs = self.env.reset()
-        self.obss = [None]*(shape[0])
+        self.obss = [None] * (shape[0])
         if self.acmodel.recurrent:
-            self.memory = torch.zeros(shape[1], self.acmodel.memory_size, device=self.device)
-            self.memories = torch.zeros(*shape, self.acmodel.memory_size, device=self.device)
+            self.memory = torch.zeros(
+                shape[1], self.acmodel.memory_size, device=self.device
+            )
+            self.memories = torch.zeros(
+                *shape, self.acmodel.memory_size, device=self.device
+            )
         self.mask = torch.ones(shape[1], device=self.device)
         self.masks = torch.zeros(*shape, device=self.device)
         self.actions = torch.zeros(*shape, device=self.device, dtype=torch.int)
@@ -94,7 +113,9 @@ class BaseAlgo(ABC):
         # Initialize log values
 
         self.log_episode_return = torch.zeros(self.num_procs, device=self.device)
-        self.log_episode_reshaped_return = torch.zeros(self.num_procs, device=self.device)
+        self.log_episode_reshaped_return = torch.zeros(
+            self.num_procs, device=self.device
+        )
         self.log_episode_num_frames = torch.zeros(self.num_procs, device=self.device)
 
         self.log_done_counter = 0
@@ -122,19 +143,19 @@ class BaseAlgo(ABC):
             Useful stats about the training process, including the average
             reward, policy loss, value loss, etc.
         """
-
         for i in range(self.num_frames_per_proc):
             # Do one agent-environment interaction
-
             preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
             with torch.no_grad():
                 if self.acmodel.recurrent:
-                    dist, value, memory = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+                    dist, value, memory = self.acmodel(
+                        preprocessed_obs, self.memory * self.mask.unsqueeze(1)
+                    )
                 else:
                     dist, value = self.acmodel(preprocessed_obs)
             action = dist.sample()
 
-            obs, reward, done, _ = self.env.step(action.cpu().numpy())
+            obs, reward, terminated, truncated, _ = self.env.step(action.cpu().numpy())
 
             # Update experiences values
 
@@ -144,29 +165,42 @@ class BaseAlgo(ABC):
                 self.memories[i] = self.memory
                 self.memory = memory
             self.masks[i] = self.mask
-            self.mask = 1 - torch.tensor(done, device=self.device, dtype=torch.float)
+            self.mask = 1 - torch.tensor(
+                terminated, device=self.device, dtype=torch.float
+            )
             self.actions[i] = action
             self.values[i] = value
             if self.reshape_reward is not None:
-                self.rewards[i] = torch.tensor([
-                    self.reshape_reward(obs_, action_, reward_, done_)
-                    for obs_, action_, reward_, done_ in zip(obs, action, reward, done)
-                ], device=self.device)
+                self.rewards[i] = torch.tensor(
+                    [
+                        self.reshape_reward(obs_, action_, reward_, terminated_)
+                        for obs_, action_, reward_, terminated_ in zip(
+                            obs, action, reward, terminated
+                        )
+                    ],
+                    device=self.device,
+                )
             else:
                 self.rewards[i] = torch.tensor(reward, device=self.device)
             self.log_probs[i] = dist.log_prob(action)
 
             # Update log values
 
-            self.log_episode_return += torch.tensor(reward, device=self.device, dtype=torch.float)
+            self.log_episode_return += torch.tensor(
+                reward, device=self.device, dtype=torch.float
+            )
             self.log_episode_reshaped_return += self.rewards[i]
-            self.log_episode_num_frames += torch.ones(self.num_procs, device=self.device)
+            self.log_episode_num_frames += torch.ones(
+                self.num_procs, device=self.device
+            )
 
-            for i, done_ in enumerate(done):
-                if done_:
+            for i, terminated_ in enumerate(terminated):
+                if terminated_:
                     self.log_done_counter += 1
                     self.log_return.append(self.log_episode_return[i].item())
-                    self.log_reshaped_return.append(self.log_episode_reshaped_return[i].item())
+                    self.log_reshaped_return.append(
+                        self.log_episode_reshaped_return[i].item()
+                    )
                     self.log_num_frames.append(self.log_episode_num_frames[i].item())
 
             self.log_episode_return *= self.mask
@@ -178,17 +212,31 @@ class BaseAlgo(ABC):
         preprocessed_obs = self.preprocess_obss(self.obs, device=self.device)
         with torch.no_grad():
             if self.acmodel.recurrent:
-                _, next_value, _ = self.acmodel(preprocessed_obs, self.memory * self.mask.unsqueeze(1))
+                _, next_value, _ = self.acmodel(
+                    preprocessed_obs, self.memory * self.mask.unsqueeze(1)
+                )
             else:
                 _, next_value = self.acmodel(preprocessed_obs)
 
         for i in reversed(range(self.num_frames_per_proc)):
-            next_mask = self.masks[i+1] if i < self.num_frames_per_proc - 1 else self.mask
-            next_value = self.values[i+1] if i < self.num_frames_per_proc - 1 else next_value
-            next_advantage = self.advantages[i+1] if i < self.num_frames_per_proc - 1 else 0
+            next_mask = (
+                self.masks[i + 1] if i < self.num_frames_per_proc - 1 else self.mask
+            )
+            next_value = (
+                self.values[i + 1] if i < self.num_frames_per_proc - 1 else next_value
+            )
+            next_advantage = (
+                self.advantages[i + 1] if i < self.num_frames_per_proc - 1 else 0
+            )
 
-            delta = self.rewards[i] + self.discount * next_value * next_mask - self.values[i]
-            self.advantages[i] = delta + self.discount * self.gae_lambda * next_advantage * next_mask
+            delta = (
+                self.rewards[i]
+                + self.discount * next_value * next_mask
+                - self.values[i]
+            )
+            self.advantages[i] = (
+                delta + self.discount * self.gae_lambda * next_advantage * next_mask
+            )
 
         # Define experiences:
         #   the whole experience is the concatenation of the experience
@@ -199,12 +247,16 @@ class BaseAlgo(ABC):
         #   - D is the dimensionality.
 
         exps = DictList()
-        exps.obs = [self.obss[i][j]
-                    for j in range(self.num_procs)
-                    for i in range(self.num_frames_per_proc)]
+        exps.obs = [
+            self.obss[i][j]
+            for j in range(self.num_procs)
+            for i in range(self.num_frames_per_proc)
+        ]
         if self.acmodel.recurrent:
             # T x P x D -> P x T x D -> (P * T) x D
-            exps.memory = self.memories.transpose(0, 1).reshape(-1, *self.memories.shape[2:])
+            exps.memory = self.memories.transpose(0, 1).reshape(
+                -1, *self.memories.shape[2:]
+            )
             # T x P -> P x T -> (P * T) x 1
             exps.mask = self.masks.transpose(0, 1).reshape(-1).unsqueeze(1)
         # for all tensors below, T x P -> P x T -> P * T
@@ -227,13 +279,13 @@ class BaseAlgo(ABC):
             "return_per_episode": self.log_return[-keep:],
             "reshaped_return_per_episode": self.log_reshaped_return[-keep:],
             "num_frames_per_episode": self.log_num_frames[-keep:],
-            "num_frames": self.num_frames
+            "num_frames": self.num_frames,
         }
 
         self.log_done_counter = 0
-        self.log_return = self.log_return[-self.num_procs:]
-        self.log_reshaped_return = self.log_reshaped_return[-self.num_procs:]
-        self.log_num_frames = self.log_num_frames[-self.num_procs:]
+        self.log_return = self.log_return[-self.num_procs :]
+        self.log_reshaped_return = self.log_reshaped_return[-self.num_procs :]
+        self.log_num_frames = self.log_num_frames[-self.num_procs :]
 
         return exps, logs
 

--- a/torch_ac/utils/penv.py
+++ b/torch_ac/utils/penv.py
@@ -1,19 +1,21 @@
-from multiprocessing import Process, Pipe
-import gym
+from multiprocess import Process, Pipe
+import gymnasium as gym
+
 
 def worker(conn, env):
     while True:
         cmd, data = conn.recv()
         if cmd == "step":
-            obs, reward, done, info = env.step(data)
-            if done:
-                obs = env.reset()
-            conn.send((obs, reward, done, info))
+            obs, reward, terminated, truncated, info = env.step(data)
+            if terminated:
+                obs, _ = env.reset()
+            conn.send((obs, reward, terminated, truncated, info))
         elif cmd == "reset":
-            obs = env.reset()
+            obs, _ = env.reset()
             conn.send(obs)
         else:
             raise NotImplementedError
+
 
 class ParallelEnv(gym.Env):
     """A concurrent execution of environments in multiple processes."""
@@ -37,16 +39,19 @@ class ParallelEnv(gym.Env):
     def reset(self):
         for local in self.locals:
             local.send(("reset", None))
-        results = [self.envs[0].reset()] + [local.recv() for local in self.locals]
+        results = [self.envs[0].reset()[0]] + [local.recv() for local in self.locals]
         return results
 
     def step(self, actions):
         for local, action in zip(self.locals, actions[1:]):
             local.send(("step", action))
-        obs, reward, done, info = self.envs[0].step(actions[0])
-        if done:
-            obs = self.envs[0].reset()
-        results = zip(*[(obs, reward, done, info)] + [local.recv() for local in self.locals])
+        obs, reward, terminated, truncated, info = self.envs[0].step(actions[0])
+        if terminated:
+            obs, _ = self.envs[0].reset()
+        results = zip(
+            *[(obs, reward, terminated, truncated, info)]
+            + [local.recv() for local in self.locals]
+        )
         return results
 
     def render(self):


### PR DESCRIPTION
Main changes:
- Retrieve 5 elements from `env.step`
- Retrieve 2 elements from `env.reset`
- Use `multiprocess` instead of `multiprocessing`, in order to be able to efficiently parallelize environments with custom observation spaces, as is the case with minigrid